### PR TITLE
Add 404 page for GitHub Pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/icon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frederick Wang</title>
+    <script type="module" crossorigin src="/assets/index-DqnzCcXi.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BfmZ1OcY.css">
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- duplicate `index.html` as `404.html` to provide a default 404 page

## Testing
- `npm test` *(fails: cannot find `package.json`)*
- `git push` *(fails: no configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_6858f56e3f3c8332881c2222b19807ee